### PR TITLE
Provide source-maps by default

### DIFF
--- a/webpack.hot.config.js
+++ b/webpack.hot.config.js
@@ -3,7 +3,7 @@ var webpack = require('webpack');
 var HtmlWebpackPlugin = require('html-webpack-plugin');
 
 module.exports = {
-  devtool: 'eval',
+  devtool: 'cheap-module-eval-source-map',
   entry: [
     'webpack-dev-server/client?http://localhost:3000',
     'webpack/hot/only-dev-server',


### PR DESCRIPTION
Provide working source-maps at dev-time out of the box, `cheap-module-eval-source-map` provides the best mix of performance and information according to http://webpack.github.io/docs/configuration.html#devtool
